### PR TITLE
Add credit validation FastAPI example

### DIFF
--- a/credit_app/README.md
+++ b/credit_app/README.md
@@ -1,0 +1,9 @@
+# Credit Validation API
+
+Esta aplicación de ejemplo muestra un flujo de validación crediticia utilizando FastAPI.
+
+## Endpoints
+- `POST /apply`: recibe los datos del cliente y devuelve si fue aprobado o no.
+- `GET /ping`: endpoint de salud.
+
+Las consultas a APIs externas, registro en Odoo y notificación se encuentran simuladas.

--- a/credit_app/__init__.py
+++ b/credit_app/__init__.py
@@ -1,0 +1,1 @@
+"""Credit validation application."""

--- a/credit_app/main.py
+++ b/credit_app/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+from .routers import credit
+
+app = FastAPI(title="Credit Validation API")
+app.include_router(credit.router)
+
+
+@app.get("/ping")
+def ping():
+    return {"status": "ok"}
+

--- a/credit_app/models.py
+++ b/credit_app/models.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+
+class ClientApplication(BaseModel):
+    nombre: str
+    cedula: str
+    direccion: str
+    telefono: str
+    correo: str
+    virtual: bool = Field(False, description="True if the card is virtual")
+
+class ValidationResult(BaseModel):
+    aprobado: bool
+    mensaje: str
+    tarjeta_virtual: Optional[bool] = None

--- a/credit_app/requirements.txt
+++ b/credit_app/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+odoorpc
+requests

--- a/credit_app/routers/__init__.py
+++ b/credit_app/routers/__init__.py
@@ -1,0 +1,3 @@
+from . import credit
+
+__all__ = ["credit"]

--- a/credit_app/routers/credit.py
+++ b/credit_app/routers/credit.py
@@ -1,0 +1,59 @@
+from fastapi import APIRouter
+from ..models import ClientApplication, ValidationResult
+from ..services import (
+    ccss,
+    sugef,
+    bcr,
+    protectora,
+    hacienda,
+    odoo_service,
+    notification,
+    shipping,
+)
+
+router = APIRouter()
+
+odoo_client = odoo_service.OdooClient()
+
+
+def evaluate(app: ClientApplication) -> ValidationResult:
+    """Evaluate the responses from all services and approve or deny."""
+    ccss_status = ccss.check_status(app.cedula)
+    sugef_cond = sugef.get_credit_condition(app.cedula)
+    bcr_hist = bcr.get_financial_history(app.cedula)
+    debt = protectora.get_active_debt(app.cedula)
+    tax = hacienda.get_tax_status(app.cedula)
+
+    approved = all(
+        (
+            ccss_status.get("status") == "ASEGURADO",
+            sugef_cond.get("condicion") == "NORMAL",
+            bcr_hist.get("historial") == "LIMPIO",
+            debt.get("deuda") == "NINGUNA",
+            tax.get("situacion") == "AL DIA",
+        )
+    )
+
+    if approved:
+        tracking = shipping.create_order(app.direccion, app.nombre)
+        odoo_client.create_lead(app.dict())
+        notification.send_email(
+            app.correo,
+            "Solicitud aprobada",
+            f"Su tarjeta sera enviada. Tracking: {tracking['tracking_id']}",
+        )
+        return ValidationResult(aprobado=True, mensaje="Aprobado", tarjeta_virtual=app.virtual)
+
+    else:
+        odoo_client.create_lead({**app.dict(), "status": "rejected"})
+        notification.send_email(
+            app.correo,
+            "Solicitud rechazada",
+            "No cumple con los criterios de aprobacion",
+        )
+        return ValidationResult(aprobado=False, mensaje="Rechazado")
+
+
+@router.post("/apply", response_model=ValidationResult)
+def apply_for_card(app: ClientApplication):
+    return evaluate(app)

--- a/credit_app/services/__init__.py
+++ b/credit_app/services/__init__.py
@@ -1,0 +1,12 @@
+from . import ccss, sugef, bcr, protectora, hacienda, odoo_service, notification, shipping
+
+__all__ = [
+    "ccss",
+    "sugef",
+    "bcr",
+    "protectora",
+    "hacienda",
+    "odoo_service",
+    "notification",
+    "shipping",
+]

--- a/credit_app/services/bcr.py
+++ b/credit_app/services/bcr.py
@@ -1,0 +1,6 @@
+"""Simulated API client for Banco de Costa Rica"""
+from typing import Dict
+
+def get_financial_history(cedula: str) -> Dict[str, str]:
+    """Return a fake financial history."""
+    return {"historial": "LIMPIO"}

--- a/credit_app/services/ccss.py
+++ b/credit_app/services/ccss.py
@@ -1,0 +1,7 @@
+"""Simulated API client for CCSS"""
+from typing import Dict
+
+def check_status(cedula: str) -> Dict[str, str]:
+    """Return a fake insurance status."""
+    # Simulate API call
+    return {"status": "ASEGURADO"}

--- a/credit_app/services/hacienda.py
+++ b/credit_app/services/hacienda.py
@@ -1,0 +1,6 @@
+"""Simulated API client for Ministerio de Hacienda"""
+from typing import Dict
+
+def get_tax_status(cedula: str) -> Dict[str, str]:
+    """Return a fake tax status."""
+    return {"situacion": "AL DIA"}

--- a/credit_app/services/notification.py
+++ b/credit_app/services/notification.py
@@ -1,0 +1,20 @@
+"""Notification service using smtplib (placeholder)."""
+from typing import Optional
+import os
+import smtplib
+from email.message import EmailMessage
+
+
+def send_email(to_address: str, subject: str, body: str) -> None:
+    host = os.getenv("SMTP_HOST", "localhost")
+    try:
+        with smtplib.SMTP(host) as server:
+            msg = EmailMessage()
+            msg["From"] = "noreply@example.com"
+            msg["To"] = to_address
+            msg["Subject"] = subject
+            msg.set_content(body)
+            server.send_message(msg)
+    except Exception:
+        # In tests or missing server, ignore
+        pass

--- a/credit_app/services/odoo_service.py
+++ b/credit_app/services/odoo_service.py
@@ -1,0 +1,25 @@
+"""Service to interact with Odoo via odoorpc."""
+from typing import Dict, Any
+import os
+
+try:
+    import odoorpc
+except ImportError:  # pragma: no cover - optional dependency
+    odoorpc = None
+
+class OdooClient:
+    def __init__(self):
+        if odoorpc:
+            host = os.getenv("ODOO_HOST", "localhost")
+            db = os.getenv("ODOO_DB", "test")
+            user = os.getenv("ODOO_USER", "admin")
+            password = os.getenv("ODOO_PASSWORD", "admin")
+            self.odoo = odoorpc.ODOO(host)
+            self.odoo.login(db, user, password)
+        else:
+            self.odoo = None
+
+    def create_lead(self, data: Dict[str, Any]) -> None:
+        if not self.odoo:
+            return
+        self.odoo.env["crm.lead"].create(data)

--- a/credit_app/services/protectora.py
+++ b/credit_app/services/protectora.py
@@ -1,0 +1,6 @@
+"""Simulated API client for Protectora de Crédito"""
+from typing import Dict
+
+def get_active_debt(cedula: str) -> Dict[str, str]:
+    """Return a fake debt report."""
+    return {"deuda": "NINGUNA"}

--- a/credit_app/services/shipping.py
+++ b/credit_app/services/shipping.py
@@ -1,0 +1,7 @@
+"""Service for interacting with mimoto.express API (placeholder)."""
+from typing import Dict
+
+
+def create_order(address: str, name: str) -> Dict[str, str]:
+    """Pretend to create a shipping order and return tracking info."""
+    return {"tracking_id": "XYZ123"}

--- a/credit_app/services/sugef.py
+++ b/credit_app/services/sugef.py
@@ -1,0 +1,6 @@
+"""Simulated API client for SUGEF"""
+from typing import Dict
+
+def get_credit_condition(cedula: str) -> Dict[str, str]:
+    """Return a fake credit condition."""
+    return {"condicion": "NORMAL"}

--- a/credit_app/tests/__init__.py
+++ b/credit_app/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests package

--- a/credit_app/tests/test_credit.py
+++ b/credit_app/tests/test_credit.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+from credit_app.main import app
+
+client = TestClient(app)
+
+def test_ping():
+    resp = client.get("/ping")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_apply_success():
+    payload = {
+        "nombre": "Juan Perez",
+        "cedula": "123",
+        "direccion": "San Jose",
+        "telefono": "5555",
+        "correo": "juan@example.com",
+        "virtual": True,
+    }
+    resp = client.post("/apply", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["aprobado"] is True
+    assert data["mensaje"] == "Aprobado"


### PR DESCRIPTION
## Summary
- implement simple FastAPI-based credit validation demo under `credit_app`
- simulate external service calls and Odoo integration
- add unit tests and basic docs
- cleanup compiled files

## Testing
- `pytest credit_app/tests/test_credit.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6848f9cc76708320be644f30e5701089